### PR TITLE
Create github-repo-stats.yml

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  j1:
+    name: repostats-for-nice-project
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          repository: microsoft/power-pages-samples
+          ghtoken: ${{ secrets.ghrs_github_api_token }}


### PR DESCRIPTION
Add a github action to publish and archive the repo stats from github using `jgehrcke/github-repo-stats` action. The stats are published to `github-repo-stats` branch which has been prepped already by deleting all the data from it to make it clean for storing the repo stats only.