### PR TITLE
Use GitHub App token for repo stats

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -12,10 +12,17 @@ jobs:
     name: repostats-for-nice-project
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GHRS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.GHRS_GITHUB_APP_PRIVATE_KEY }}
+
       - name: run-ghrs
         uses: jgehrcke/github-repo-stats@RELEASE
         with:
           repository: microsoft/power-pages-samples
-          ghtoken: ${{ secrets.ghrs_github_api_token }}
+          ghtoken: ${{ steps.app-token.outputs.token }}
           databranch: github-repo-stats
           ghpagesprefix: https://microsoft.github.io/power-pages-samples

--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -16,7 +16,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.GHRS_GITHUB_APP_ID }}
+          app-id: 3189942
           private-key: ${{ secrets.GHRS_GITHUB_APP_PRIVATE_KEY }}
 
       - name: run-ghrs


### PR DESCRIPTION
The repo stats workflow should not depend on a personal access token. This updates the scheduled stats job to mint a short-lived GitHub App installation token and pass it to the existing repo stats action.

The workflow now uses `actions/create-github-app-token@v2` with the shared GitHub App ID `3189942` from the Power Platform Skills repo stats workflow and the `GHRS_GITHUB_APP_PRIVATE_KEY` secret, then feeds the generated token into `jgehrcke/github-repo-stats`.