### PR TITLE
Add BYOC bundle file patterns

### DIFF
--- a/samples/bring-your-own-code/angular/car-sales-website/powerpages.config.json
+++ b/samples/bring-your-own-code/angular/car-sales-website/powerpages.config.json
@@ -3,5 +3,11 @@
     "siteName": "Car Sales Management - Angular",
     "defaultLandingPage": "index.html",
     "compiledPath": "dist/app/browser",
+    "bundleFilePatterns": [
+        "main-*.js",
+        "polyfills-*.js",
+        "chunk-*.js",
+        "styles-*.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/react/authentication-sample/powerpages.config.json
+++ b/samples/bring-your-own-code/react/authentication-sample/powerpages.config.json
@@ -2,5 +2,9 @@
   "$schema": "https://www.schemastore.org/powerpages.config.json",
   "siteName": "Smoking Burgers",
   "compiledPath": "dist",
-  "defaultLandingPage": "index.html"
+  "defaultLandingPage": "index.html",
+  "bundleFilePatterns": [
+    "index-*.js",
+    "index-*.css"
+  ]
 }

--- a/samples/bring-your-own-code/react/car-sales-website/powerpages.config.json
+++ b/samples/bring-your-own-code/react/car-sales-website/powerpages.config.json
@@ -2,5 +2,9 @@
     "compiledPath": "dist",
     "siteName": "Car Sales Management",
     "defaultLandingPage": "index.html",
+    "bundleFilePatterns": [
+        "index-*.js",
+        "index-*.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/react/credit-cards-website/powerpages.config.json
+++ b/samples/bring-your-own-code/react/credit-cards-website/powerpages.config.json
@@ -3,5 +3,9 @@
     "compiledPath": "dist",
     "defaultLandingPage": "index.html",
     "siteName": "WoodGrove Bank Credit Cards",
+    "bundleFilePatterns": [
+        "index-*.js",
+        "index-*.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/react/environment-variables-samples/vite-framework/powerpages.config.json
+++ b/samples/bring-your-own-code/react/environment-variables-samples/vite-framework/powerpages.config.json
@@ -3,5 +3,9 @@
     "compiledPath": "dist",
     "defaultLandingPage": "index.html",
     "siteName": "Vite - React Env Vars Sample",
+    "bundleFilePatterns": [
+        "index-*.js",
+        "index-*.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/react/fluent-ui-sample/powerpages.config.json
+++ b/samples/bring-your-own-code/react/fluent-ui-sample/powerpages.config.json
@@ -3,5 +3,9 @@
     "compiledPath": "dist",
     "defaultLandingPage": "index.html",
     "siteName": "Bank Loan Application",
+    "bundleFilePatterns": [
+        "index.js",
+        "index.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/react/localization-sample/powerpages.config.json
+++ b/samples/bring-your-own-code/react/localization-sample/powerpages.config.json
@@ -3,5 +3,9 @@
     "compiledPath": "dist",
     "siteName": "Contoso Blogs",
     "defaultLandingPage": "index.html",
+    "bundleFilePatterns": [
+        "index-*.js",
+        "index-*.css"
+    ],
     "includeSource": true
 }

--- a/samples/bring-your-own-code/vue/vue-admin-template/powerpages.config.json
+++ b/samples/bring-your-own-code/vue/vue-admin-template/powerpages.config.json
@@ -3,5 +3,9 @@
   "siteName": "Vue Admin Template",
   "defaultLandingPage": "index.html",
   "compiledPath": "dist" ,
+  "bundleFilePatterns": [
+    "index-*.js",
+    "index-*.css"
+  ],
   "includeSource": true
 }


### PR DESCRIPTION
Bring Your Own Code samples should make bundle cleanup behavior explicit so users can learn how to configure `bundleFilePatterns` from working examples.

This adds `bundleFilePatterns` to each BYOC `powerpages.config.json` using filename patterns that match the generated bundle files. The patterns intentionally omit path prefixes because the CLI matches bundle patterns against web-file directory/file names, not compiled-relative paths.

Validation:
- Built each BYOC sample to inspect generated bundle filenames
- Verified all updated configs parse as JSON
- Checked that configured patterns are filename-only