### PR TITLE
Replace PAT auth in github-repo-stats with GitHub App token

### DIFF
--- a/.github/workflows/github-repo-stats.yml
+++ b/.github/workflows/github-repo-stats.yml
@@ -7,15 +7,25 @@ on:
     - cron: "0 23 * * *"
   workflow_dispatch: # Allow for running this manually.
 
+permissions:
+  contents: read
+
 jobs:
   j1:
     name: repostats-for-nice-project
     runs-on: ubuntu-latest
     steps:
+      - name: generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 2740120
+          private-key: ${{ secrets.POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY }}
+
       - name: run-ghrs
         uses: jgehrcke/github-repo-stats@RELEASE
         with:
           repository: microsoft/power-pages-samples
-          ghtoken: ${{ secrets.ghrs_github_api_token }}
+          ghtoken: ${{ steps.app-token.outputs.token }}
           databranch: github-repo-stats
           ghpagesprefix: https://microsoft.github.io/power-pages-samples


### PR DESCRIPTION
## Problem

The daily `github-repo-stats` workflow authenticated with a fine-grained PAT (`GHRS_GITHUB_API_TOKEN`). The *Microsoft Open Source* enterprise now forbids fine-grained PATs whose lifetime exceeds 8 days, so the run fails with a 403 from the traffic fetch. PATs can't be generated via API, so a static PAT secret can't be kept valid.

## Change

Mint a short-lived (~1 hour) GitHub App installation token at run time and pass it to the action instead of the PAT, using App id `2740120` and the `POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY` secret. The App's private key doesn't expire and the token is auto-minted per run, so there's no 7-day rotation to maintain.

The default `GITHUB_TOKEN` is set to read-only since all API/git work uses the App token.

## Required before this works

- The App must be **installed on `microsoft/power-pages-samples`** with **Administration: Read** (required by the repository traffic API for views/clones) and **Contents: Read and write** (to push to the `github-repo-stats` data branch).
- The `POWER_PAGES_PUBLIC_GITHUB_APP_PRIVATE_KEY` secret must be available to this repo (repo or org level).

## Cleanup

The old `GHRS_GITHUB_API_TOKEN` PAT secret is now unused and can be deleted.