### PR TITLE
Ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## Summary
1. Add `.DS_Store` to the root `.gitignore`.

## Testing
1. Verified `samples/.DS_Store` is ignored with `git check-ignore -v samples/.DS_Store`.

This keeps local macOS metadata out of future commits.