### PR TITLE
Fix react-router Dependabot alerts in React SPA samples

### DIFF
--- a/samples/spa/apps/car-sales-website/react/package-lock.json
+++ b/samples/spa/apps/car-sales-website/react/package-lock.json
@@ -16,7 +16,7 @@
         "formik": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.1",
         "yup": "^1.3.0"
       },
       "devDependencies": {
@@ -1397,15 +1397,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2457,6 +2448,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha1-O7m9/II2nbnC9pyTycPOsxDIizw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3974,35 +3978,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha1-YSWdFZS5XBrOKZ7kxXRTVw8MIvE=",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha1-DRsTjikTkwWa1IHD4Q42Y4WpeKQ=",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {
@@ -4169,6 +4179,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha1-zNCGc6muXS5E6iot4lCJ5nx+32g=",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/samples/spa/apps/car-sales-website/react/package.json
+++ b/samples/spa/apps/car-sales-website/react/package.json
@@ -18,7 +18,7 @@
     "formik": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.1",
     "yup": "^1.3.0"
   },
   "devDependencies": {

--- a/samples/spa/apps/credit-cards-website/react/package-lock.json
+++ b/samples/spa/apps/credit-cards-website/react/package-lock.json
@@ -52,7 +52,7 @@
                 "react-dom": "^18.3.1",
                 "react-hook-form": "^7.53.0",
                 "react-resizable-panels": "^2.1.3",
-                "react-router-dom": "^6.30.4",
+                "react-router-dom": "^7.18.1",
                 "recharts": "^2.12.7",
                 "sonner": "^1.5.0",
                 "tailwind-merge": "^2.2.1",
@@ -2626,15 +2626,6 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
-        "node_modules/@remix-run/router": {
-            "version": "1.23.3",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-            "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.27",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -4131,6 +4122,19 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/cookie": {
+            "version": "1.1.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha1-O7m9/II2nbnC9pyTycPOsxDIizw=",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -5811,35 +5815,41 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-            "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+            "version": "7.18.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router/-/react-router-7.18.1.tgz",
+            "integrity": "sha1-YSWdFZS5XBrOKZ7kxXRTVw8MIvE=",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3"
+                "cookie": "^1.0.1",
+                "set-cookie-parser": "^2.6.0"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.30.4",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-            "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+            "version": "7.18.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router-dom/-/react-router-dom-7.18.1.tgz",
+            "integrity": "sha1-DRsTjikTkwWa1IHD4Q42Y4WpeKQ=",
             "license": "MIT",
             "dependencies": {
-                "@remix-run/router": "1.23.3",
-                "react-router": "6.30.4"
+                "react-router": "7.18.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": ">=18",
+                "react-dom": ">=18"
             }
         },
         "node_modules/react-smooth": {
@@ -6095,6 +6105,12 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/set-cookie-parser": {
+            "version": "2.7.2",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+            "integrity": "sha1-zNCGc6muXS5E6iot4lCJ5nx+32g=",
+            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",

--- a/samples/spa/apps/credit-cards-website/react/package.json
+++ b/samples/spa/apps/credit-cards-website/react/package.json
@@ -55,7 +55,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.1",
         "recharts": "^2.12.7",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.2.1",

--- a/samples/spa/snippets/authentication/package-lock.json
+++ b/samples/spa/snippets/authentication/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.1.0"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
@@ -1322,8 +1322,8 @@
     },
     "node_modules/cookie": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha1-O7m9/II2nbnC9pyTycPOsxDIizw=",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha1-YSWdFZS5XBrOKZ7kxXRTVw8MIvE=",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -1686,12 +1686,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
-      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha1-DRsTjikTkwWa1IHD4Q42Y4WpeKQ=",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.15.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1764,8 +1764,8 @@
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha1-zNCGc6muXS5E6iot4lCJ5nx+32g=",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/samples/spa/snippets/authentication/package.json
+++ b/samples/spa/snippets/authentication/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.1.0"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/samples/spa/snippets/localization/package-lock.json
+++ b/samples/spa/snippets/localization/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-i18next": "^17.0.8",
-        "react-router-dom": "^6.30.4"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@types/node": "^22.15.21",
@@ -1396,15 +1396,6 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2389,6 +2380,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha1-O7m9/II2nbnC9pyTycPOsxDIizw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3689,35 +3693,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha1-YSWdFZS5XBrOKZ7kxXRTVw8MIvE=",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha1-DRsTjikTkwWa1IHD4Q42Y4WpeKQ=",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-transition-group": {
@@ -3884,6 +3894,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha1-zNCGc6muXS5E6iot4lCJ5nx+32g=",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/samples/spa/snippets/localization/package.json
+++ b/samples/spa/snippets/localization/package.json
@@ -18,7 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^17.0.8",
-    "react-router-dom": "^6.30.4"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@types/node": "^22.15.21",


### PR DESCRIPTION
Fixes the four open react-router Dependabot alerts (491, 492, 493, 494) by moving every affected sample to `react-router-dom` 7.18.1.

## What changed

| Sample | Before | After | Alert |
| --- | --- | --- | --- |
| `samples/spa/snippets/authentication` | `^7.1.0` | `^7.18.1` | 494 - GHSA-h8fp-f39c-q6mh (CVE-2026-53667) |
| `samples/spa/apps/car-sales-website/react` | `^6.30.4` | `^7.18.1` | 492 - GHSA-jjmj-jmhj-qwj2 (CVE-2026-53668) |
| `samples/spa/apps/credit-cards-website/react` | `^6.30.4` | `^7.18.1` | 493 - same advisory |
| `samples/spa/snippets/localization` | `^6.30.4` | `^7.18.1` | 491 - same advisory |

The 6.x line has no patched release (the advisory lists `>= 6.30.2, <= 6.30.4` with no fix, and 6.30.4 is the last v6), so v7 is the only remediation for the three v6 samples.

## Why the v6 -> v7 jump is safe here

These samples only use `BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `Navigate`, `useNavigate`, `useParams` and `useLocation`, all unchanged in v7, with flat absolute route paths and no data-router APIs. They already run React 18, which satisfies the v7 peer requirement. No source changes were needed.

## Verification

- `npm run build` passes in all four samples.
- Browser pass over each built sample via `vite preview`: pages render, client-side navigation works (including the `/blog/:id` param route in the localization sample and the `useNavigate` sidebar in car-sales), and no router errors in the console. The only console noise is the expected `/_api` and anti-forgery failures that happen when running outside the Power Pages host.

## Known remaining audit finding

`npm audit` still flags GHSA-qwww-vcr4-c8h2 against `react-router >= 7.12.0`. It only affects the unstable RSC APIs, which none of these samples use, and its first patched version (8.3.0) is not published yet. Downgrading to 7.11.0 would reintroduce alert 494.

Only `package.json` and `package-lock.json` are touched, matching the pattern of previous Dependabot fixes in this repo; the `.powerpages-site` snapshots are regenerated by the deployment tooling, not by hand.