### PR TITLE
Add template Dataverse language metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,10 @@ To contribute a template:
 7. Run `node templates/scripts/validate-templates.js`.
 8. Open a pull request and follow the existing CLA bot instructions.
 
+Set `requiredDataverseLanguages` to the Dataverse language LCIDs the template needs before import.
+Use `[1033]` for templates that only require English (United States).
+Add every LCID required by localized solution components.
+
 Preview images listed in the manifest must be `.png` files.
 Do not list placeholder screenshots.
 If screenshots or seed data are not ready, leave `previewImages` empty or omit `seedDataPath`, then add a short README in the template folder that explains what is missing.

--- a/templates/README.md
+++ b/templates/README.md
@@ -4,7 +4,7 @@ Templates are installable Power Pages starting points.
 They are different from `samples/`: templates are meant to be imported into an environment, while samples are learning examples that explain a pattern or capability.
 
 The central catalog is [`manifest.json`](manifest.json).
-Each entry points to a solution zip, preview images, and optional seed data.
+Each entry points to a solution zip, preview images, required Dataverse languages, and optional seed data.
 The schema for the catalog is [`schemas/templates-manifest.schema.json`](schemas/templates-manifest.schema.json).
 
 ## Template categories

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -27,6 +27,9 @@
       ],
       "solutionPath": "spa/311-portal/solution/311-portal-unmanaged.zip",
       "seedDataPath": "spa/311-portal/seed/data.json",
+      "requiredDataverseLanguages": [
+        1033
+      ],
       "templateVersion": "1.0.0.1",
       "author": "Microsoft"
     },
@@ -57,6 +60,9 @@
       ],
       "solutionPath": "spa/supplier-invoice-portal/solution/supplier-invoice-spa-portal-unmanaged.zip",
       "seedDataPath": "spa/supplier-invoice-portal/seed/data.json",
+      "requiredDataverseLanguages": [
+        1033
+      ],
       "templateVersion": "1.0.0.1",
       "author": "Microsoft"
     }

--- a/templates/schemas/templates-manifest.schema.json
+++ b/templates/schemas/templates-manifest.schema.json
@@ -26,6 +26,7 @@
           "audience",
           "previewImages",
           "solutionPath",
+          "requiredDataverseLanguages",
           "templateVersion",
           "author"
         ],
@@ -98,6 +99,15 @@
           "seedDataPath": {
             "type": "string",
             "pattern": "^.+\\.json$"
+          },
+          "requiredDataverseLanguages": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
           },
           "templateVersion": {
             "type": "string",

--- a/templates/scripts/validate-templates.js
+++ b/templates/scripts/validate-templates.js
@@ -81,6 +81,10 @@ function validateAgainstSchema(value, schema, location, result) {
     }
   }
 
+  if (typeof value === "number" && Number.isFinite(schema.minimum) && value < schema.minimum) {
+    result.errors.push(`${location} must be greater than or equal to ${schema.minimum}.`);
+  }
+
   if (Array.isArray(value)) {
     if (schema.minItems && value.length < schema.minItems) {
       result.errors.push(`${location} must contain at least ${schema.minItems} item(s).`);
@@ -122,6 +126,10 @@ function validateAgainstSchema(value, schema, location, result) {
 function matchesType(value, expectedType) {
   if (expectedType === "array") {
     return Array.isArray(value);
+  }
+
+  if (expectedType === "integer") {
+    return Number.isInteger(value);
   }
 
   if (expectedType === "object") {

--- a/templates/scripts/validate-templates.test.js
+++ b/templates/scripts/validate-templates.test.js
@@ -60,6 +60,29 @@ test("rejects invalid ids and folder mismatches", () => {
   assert(result.errors.some((error) => error.includes("must live in spa/Bad_Id")));
 });
 
+test("rejects missing or invalid required Dataverse languages", () => {
+  const missingRoot = createTemplateRoot({
+    requiredDataverseLanguages: undefined
+  });
+
+  const missingResult = validateTemplates({ root: missingRoot });
+  assert(missingResult.errors.some((error) => error.includes("$.templates[0].requiredDataverseLanguages is required")));
+
+  const invalidRoot = createTemplateRoot({
+    requiredDataverseLanguages: [1033, "1036"]
+  });
+
+  const invalidResult = validateTemplates({ root: invalidRoot });
+  assert(invalidResult.errors.some((error) => error.includes("$.templates[0].requiredDataverseLanguages[1] must be integer")));
+
+  const nonPositiveRoot = createTemplateRoot({
+    requiredDataverseLanguages: [0]
+  });
+
+  const nonPositiveResult = validateTemplates({ root: nonPositiveRoot });
+  assert(nonPositiveResult.errors.some((error) => error.includes("$.templates[0].requiredDataverseLanguages[0] must be greater than or equal to 1")));
+});
+
 test("rejects missing solution.xml, Git LFS pointers, non-PNG previews, and malformed seed data", () => {
   const root = createTemplateRoot({
     solutionXml: null,
@@ -276,9 +299,14 @@ function createTemplateRoot(options = {}) {
     audience: ["developers"],
     previewImages: options.previewImages ?? [],
     solutionPath,
+    requiredDataverseLanguages: options.requiredDataverseLanguages ?? [1033],
     templateVersion: "1.0.0",
     author: "Test"
   };
+
+  if (Object.hasOwn(options, "requiredDataverseLanguages") && options.requiredDataverseLanguages === undefined) {
+    delete template.requiredDataverseLanguages;
+  }
 
   if (options.seedDataPath) {
     template.seedDataPath = options.seedDataPath;


### PR DESCRIPTION
Template consumers need to know which Dataverse languages must be enabled before importing each installable template. This adds that requirement to the templates manifest instead of treating en-US as a global assumption.

This PR adds `requiredDataverseLanguages` to the manifest schema as a required non-empty array of integer LCIDs, sets `[1033]` on the existing templates, and teaches the custom validator to handle `integer` and `minimum` schema checks. The validator tests now cover missing, non-integer, and non-positive language values.

Validation:
- `node --test templates/scripts/validate-templates.test.js`
- `node templates/scripts/validate-templates.js`