### PR TITLE
Improve malware-scan sample README (production auth, upload flow, link fixes)

### DIFF
--- a/samples/server-logic/malware-scan/readme.md
+++ b/samples/server-logic/malware-scan/readme.md
@@ -26,27 +26,29 @@ clean**.
 ## How it works
 
 ```
- Browser (basic form)                 Azure Blob Storage            Power Pages
- ────────────────────                 ──────────────────            ───────────
+ Browser (basic form)          Power Pages                 Azure Blob Storage
+ ────────────────────          ───────────                 ──────────────────
  1. User picks file(s)
- 2. Upload control  ───── uploads ──▶ <container>/<AnnotationId>/…
-                                              │
-                                       3. Defender for Storage
-                                          scans the blob and writes
-                                          a "Malware Scanning scan
-                                          result" index tag
- 4. Custom JS polls  ─── directory ─────────────────────────────▶ server logic
-    the server logic     (AnnotationId)                            (malware-scan)
-                                              │                          │
-                                       5. List Blobs (include=tags) ◀────┘
-                                          returns scan result per file
- 6. JS renders a status badge per file  ◀──── { files: [ {scanStatus} ] }
- 7. Submit stays disabled until every file is "Clean"
+ 2. Upload control  ── file ──▶ 3. Power Pages stores the
+                                   file on the user's behalf ──▶ <container>/<AnnotationId>/…
+                                                                       │
+                                                                4. Defender for Storage
+                                                                   scans the blob and writes
+                                                                   a "Malware Scanning scan
+                                                                   result" index tag
+ 5. Custom JS polls ─ directory ▶ server logic (malware-scan)
+    the server logic  (AnnotationId)            │
+                                        6. List Blobs (include=tags) ──▶ reads scan tag
+                                           returns scan result per file  ◀──┘
+ 7. JS renders a status badge per file  ◀──── { files: [ {scanStatus} ] }
+ 8. Submit stays disabled until every file is "Clean"
 ```
 
-* When a file is attached, Power Pages stores it in the container under a virtual
-  folder named after the attachment's **AnnotationId** (a GUID with the hyphens
-  removed).
+* The browser upload control sends the file to **Power Pages** (via the built-in
+  `/_api/file/...` endpoints) — the client never talks to Blob Storage directly.
+  Power Pages stores the file in the container on the user's behalf, under a
+  virtual folder named after the attachment's **AnnotationId** (a GUID with the
+  hyphens removed).
 * The custom JavaScript captures that `AnnotationId` from the
   `InitializeFileUpload` response and passes it to the server logic as the
   `directory` query parameter.
@@ -75,7 +77,7 @@ Before you start, make sure you have:
 * An **Azure Storage account** (general-purpose v2).
 * **Microsoft Defender for Storage** enabled on the storage account (with the
   **malware scanning** feature turned on). See
-  [Enable and configure Defender for Storage](https://learn.microsoft.com/azure/defender-for-cloud/defender-for-storage-configure).
+  [Enable Microsoft Defender for Storage](https://learn.microsoft.com/azure/defender-for-cloud/tutorial-enable-storage-plan).
 * Permission to generate a **container-level SAS token**.
 
 ## Step 3: Configure the Azure Blob container for attachment storage
@@ -86,7 +88,7 @@ Before you start, make sure you have:
    required **CORS** rule on the storage account (Blob service). At minimum, allow
    your site origin for `GET, PUT, POST, OPTIONS` with the headers Power Pages
    needs. See
-   [Configure Azure Blob Storage for attachments](https://learn.microsoft.com/power-pages/configure/configure-attachment-storage).
+   [Enable Azure Blob Storage for attachments](https://learn.microsoft.com/en-us/power-pages/configure/enable-azure-storage).
 3. Confirm **Defender for Storage** malware scanning is **On** for this account.
 
 ## Step 4: Generate a container SAS token
@@ -111,6 +113,11 @@ az storage container generate-sas \
 
 Copy the generated token string (everything after the `?`). You will use it in
 the next step.
+
+> **Production recommendation.** This sample authenticates to Blob Storage with a
+> SAS token to keep setup simple. For production workloads, prefer **Microsoft
+> Entra ID** authentication instead — see
+> [Recommended for production: Entra ID authentication](#recommended-for-production-entra-id-authentication).
 
 ## Step 5: Import the site and set the environment variables
 
@@ -203,12 +210,46 @@ the example below, a clean file is confirmed and the user can submit:
 * **Server-side enforcement.** This sample blocks *submission* in the browser and
   surfaces the result to the user. It does not, by itself, prevent a determined
   user from bypassing the client.
-* **SAS token scope.** Use the least-privilege permissions (`rlt`) and the
-  shortest practical expiry, and rotate the token before it expires. The token is
-  stored as an environment variable, not in code.
+* **SAS token scope.** This sample uses a SAS token for simplicity. If you keep
+  SAS, use least-privilege permissions (`rlt`) and the shortest practical expiry,
+  rotate it before it expires, and store it as an environment variable (not in
+  code). For production, prefer Entra ID authentication (see below).
 * **Input validation.** The server logic validates the `directory` value as an
   annotation GUID, which prevents arbitrary prefixes from enumerating the whole
   container.
 * **Defender dependency.** If Defender for Storage is not enabled, files are never
   tagged; the server logic returns `ScanUnavailable` after a short timeout so the
   user is not blocked indefinitely and Submit stays disabled.
+
+## Recommended for production: Entra ID authentication
+
+This sample connects to Azure Blob Storage with a **SAS token** because it is the
+simplest option to get started. A SAS token is a long-lived shared secret that
+must be rotated manually and grants access to anyone who holds it, so it is **not
+recommended for production workloads**.
+
+For production, authenticate with **Microsoft Entra ID** using an app
+registration (service principal) and Azure RBAC instead:
+
+1. **Register an app** in Microsoft Entra ID and create a client secret. Store the
+   secret in **Azure Key Vault** and reference it from an environment variable —
+   never in code.
+2. **Assign an RBAC role** on the storage account or container. For this sample's
+   read-and-list-tags access, **Storage Blob Data Reader** is sufficient.
+3. **Acquire a token** in the server logic with the client-credentials flow and
+   call the Blob REST API with a bearer token instead of a SAS token:
+
+   ```javascript
+   const tokenResp = await Server.Connector.HttpClient.PostAsync(
+     `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`,
+     `client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}` +
+       `&scope=https://storage.azure.com/.default&grant_type=client_credentials`,
+     { "Content-Type": "application/x-www-form-urlencoded" },
+     "application/x-www-form-urlencoded"
+   );
+   const accessToken = JSON.parse(JSON.parse(tokenResp).Body).access_token;
+
+   // Then call List Blobs with the bearer token instead of appending a SAS:
+   // GetAsync(listUrl, { Authorization: `Bearer ${accessToken}`, "x-ms-version": AZURE_BLOB_API_VERSION })
+   ```
+


### PR DESCRIPTION
## Summary

Follow-up improvements to the `malware-scan` server-logic sample README (merged in #125). No code or solution changes — documentation only.

## Changes

- **Production authentication guidance:** added a "Recommended for production: Entra ID authentication" section, since the sample uses a SAS token only for simplicity. Cross-referenced from the SAS step and security notes.
- **Clarified the upload flow** in *How it works*: the browser uploads through the Power Pages `/_api/file/...` endpoints (Power Pages stores the file in Blob Storage on the user's behalf) — the client never talks to Blob Storage directly.
- **Fixed broken documentation links:**
  - Attachment storage → `enable-azure-storage`
  - Defender for Storage enablement → `tutorial-enable-storage-plan`
  - Verified all remaining links are reachable.