### PR TITLE
Fix Dependabot alerts in SPA samples

### DIFF
--- a/samples/spa/apps/car-sales-website/angular/package-lock.json
+++ b/samples/spa/apps/car-sales-website/angular/package-lock.json
@@ -7857,8 +7857,8 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.2",
-      "integrity": "sha1-HiJa8y+woXjbjxTX2bqT/yRIVpQ=",
+      "version": "4.1.3",
+      "integrity": "sha1-VuPhkAmVda92N7skJGaCc3NINtI=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/car-sales-website/angular/package.json
+++ b/samples/spa/apps/car-sales-website/angular/package.json
@@ -48,7 +48,7 @@
     "qs": "6.15.2",
     "shell-quote": "1.9.0",
     "brace-expansion": "1.1.16",
-    "fast-uri": "4.1.2",
+    "fast-uri": "4.1.3",
     "@hono/node-server": "2.0.10",
     "esbuild": "0.28.1",
     "@babel/core": "7.29.6",

--- a/samples/spa/apps/credit-cards-website/react/package-lock.json
+++ b/samples/spa/apps/credit-cards-website/react/package-lock.json
@@ -4917,8 +4917,8 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.18",
+      "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "funding": [
         {
           "type": "github",
@@ -5224,22 +5224,9 @@
         "postcss": "^8.2.14"
       }
     },
-    "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.10",
-      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
-      "dev": true,
+      "version": "6.1.3",
+      "integrity": "sha1-L95jE0KfKfY9uLQXpYgJB0Ybn/E=",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -5866,18 +5853,6 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/thenify": {

--- a/samples/spa/apps/credit-cards-website/react/package.json
+++ b/samples/spa/apps/credit-cards-website/react/package.json
@@ -84,6 +84,8 @@
     },
     "overrides": {
         "esbuild": "0.28.1",
-        "js-yaml": "4.3.1"
+        "js-yaml": "4.3.1",
+        "nanoid": "3.3.18",
+        "postcss-selector-parser": "6.1.3"
     }
 }

--- a/samples/spa/apps/vue-admin-template/vue/package-lock.json
+++ b/samples/spa/apps/vue-admin-template/vue/package-lock.json
@@ -1118,8 +1118,8 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
+      "version": "3.3.18",
+      "integrity": "sha1-9mot4Rmf/eD88hyKXxMQaxwIGRM=",
       "funding": [
         {
           "type": "github",

--- a/samples/spa/apps/vue-admin-template/vue/package.json
+++ b/samples/spa/apps/vue-admin-template/vue/package.json
@@ -18,6 +18,9 @@
     "@vitejs/plugin-vue": "^6.0.7",
     "vite": "^8.0.16"
   },
+  "overrides": {
+    "nanoid": "3.3.18"
+  },
   "engines": {
     "node": "^20.19.0 || >=22.12.0",
     "npm": ">= 10.0.0"


### PR DESCRIPTION
Seven Dependabot alerts affect transitive build dependencies in the Angular, React, and Vue SPA samples.

This updates the existing `fast-uri` override to 4.1.3 and adds targeted overrides for `nanoid` 3.3.18 and `postcss-selector-parser` 6.1.3. The regenerated lockfiles resolve all affected dependency paths to patched versions without upgrading the surrounding frameworks.

Validation:
- Built all three affected SPA samples
- Ran all 5 Angular tests successfully
- Confirmed the dependency trees resolve only patched versions