### PR TITLE
Fix Browserslist vulnerability across SPA samples

### DIFF
--- a/samples/spa/apps/car-sales-website/angular/package-lock.json
+++ b/samples/spa/apps/car-sales-website/angular/package-lock.json
@@ -6257,8 +6257,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6390,8 +6390,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -6409,11 +6409,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6562,8 +6562,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -7363,8 +7363,8 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.380",
-      "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -10500,8 +10500,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13029,8 +13029,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/car-sales-website/react/package-lock.json
+++ b/samples/spa/apps/car-sales-website/react/package-lock.json
@@ -2113,8 +2113,8 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2146,8 +2146,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -2165,11 +2165,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2199,8 +2199,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -2409,8 +2409,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -2506,7 +2506,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3405,10 +3405,13 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4097,8 +4100,8 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/credit-cards-website/react/package-lock.json
+++ b/samples/spa/apps/credit-cards-website/react/package-lock.json
@@ -3653,8 +3653,8 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3697,8 +3697,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -3716,11 +3716,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3747,8 +3747,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -4096,8 +4096,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -4177,7 +4177,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4949,10 +4949,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6009,8 +6012,8 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/authentication/package-lock.json
+++ b/samples/spa/snippets/authentication/package-lock.json
@@ -1162,8 +1162,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.31",
-      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1174,8 +1174,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1193,11 +1193,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1207,8 +1207,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1268,8 +1268,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.360",
-      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1316,7 +1316,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1427,10 +1427,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.44",
-      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1688,8 +1691,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/cloud-flow/package-lock.json
+++ b/samples/spa/snippets/cloud-flow/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1616,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/environment-variables/package-lock.json
+++ b/samples/spa/snippets/environment-variables/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,10 +1430,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1613,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/file-upload/azure-blob/package-lock.json
+++ b/samples/spa/snippets/file-upload/azure-blob/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.380",
-      "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1616,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/file-upload/file-column/package-lock.json
+++ b/samples/spa/snippets/file-upload/file-column/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1616,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/file-upload/notes/package-lock.json
+++ b/samples/spa/snippets/file-upload/notes/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1616,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/file-upload/sharepoint/package-lock.json
+++ b/samples/spa/snippets/file-upload/sharepoint/package-lock.json
@@ -1167,8 +1167,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1179,8 +1179,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -1198,11 +1198,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1212,8 +1212,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -1261,8 +1261,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.381",
-      "integrity": "sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -1309,7 +1309,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1616,8 +1616,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/fluent-ui/package-lock.json
+++ b/samples/spa/snippets/fluent-ui/package-lock.json
@@ -2735,8 +2735,8 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2747,8 +2747,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -2766,11 +2766,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2780,8 +2780,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -2828,8 +2828,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -2897,7 +2897,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3023,10 +3023,13 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3255,8 +3258,8 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/localization/package-lock.json
+++ b/samples/spa/snippets/localization/package-lock.json
@@ -2074,8 +2074,8 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "integrity": "sha1-JgeMeksIKZZW6n3c6uvslV3EQwM=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2107,8 +2107,8 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
       "dev": true,
       "funding": [
         {
@@ -2126,11 +2126,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2148,8 +2148,8 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "integrity": "sha1-SXC0d96jJ4N03pvEOqj105/DzaI=",
       "dev": true,
       "funding": [
         {
@@ -2318,8 +2318,8 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.417",
+      "integrity": "sha1-XC/rRnDt+t+IyGxRiGZ1gC9YSXU=",
       "dev": true,
       "license": "ISC"
     },
@@ -2382,7 +2382,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3138,10 +3138,13 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "integrity": "sha1-Ca8X1WR6qfIh7FzyvsuVtoqYGv4=",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3818,8 +3821,8 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "integrity": "sha1-nZn7/1bFC7Ebpf01zs5ZFtpZWDY=",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Why

Addresses all 12 open high-severity Dependabot alerts for [CVE-2026-73088 / GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g).
Malformed custom browser statistics can crash Browserslist during normal build queries or change the prototype of its normalized statistics object.

## Changes

Update Browserslist from 4.28.2 and 4.28.4 to 4.28.8 in all 12 affected sample lockfiles using npm, including its required dependency updates.
Existing dependency ranges already permit the patched version, so no overrides, dependency manifest changes, or application code changes are needed.
Lockfiles retain their existing registry-neutral format.

## Validation

- Clean dependency installs and production builds succeeded for all 12 affected samples.
- All 5 Angular tests passed in ChromeHeadless; the other affected samples have no test scripts.
- Reproduced the reported TypeError on 4.28.2, then confirmed six prototype-member stats inputs return normal results on 4.28.8 in every affected sample.
- Confirmed final lockfiles match the tested installed dependency versions and integrity values.