### PR TITLE
Align SPA template choice values

### DIFF
--- a/templates/scripts/validate-templates.js
+++ b/templates/scripts/validate-templates.js
@@ -9,6 +9,7 @@ const VALID_KINDS = new Set(["spa", "traditional"]);
 const VALID_FRAMEWORKS = new Set(["angular", "astro", "none", "react", "vue"]);
 const VALID_AUDIENCES = new Set(["admins", "developers", "makers", "partners"]);
 const KEBAB_CASE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DATAVERSE_CHOICE_VALUES_FILE = "dataverse-choice-values.json";
 const FORBIDDEN_WEBSITE_CODE_DIRECTORIES = new Set([
   ".git",
   ".playwright-mcp",
@@ -283,7 +284,7 @@ function validateReferencedPaths(template, label, root, result) {
       continue;
     }
 
-    validateVariantPath(template, framework, label, root, result);
+    validateVariantPath(template, framework, label, root, solutionMetadata, result);
   }
 
   if (typeof template.seedDataPath === "string") {
@@ -307,7 +308,7 @@ function getFamilyBasePath(template) {
   return `${template.kind}/${template.id}`;
 }
 
-function validateVariantPath(template, framework, label, root, result) {
+function validateVariantPath(template, framework, label, root, solutionMetadata, result) {
   const variantBase = `${getFamilyBasePath(template)}/variants/${framework}`;
   validateVariantDirectoryContents(label, root, variantBase, result);
   validateWebsiteCodePath(
@@ -315,6 +316,7 @@ function validateVariantPath(template, framework, label, root, result) {
     label,
     root,
     `${variantBase}/website-code`,
+    solutionMetadata,
     result
   );
 }
@@ -605,6 +607,7 @@ function parseDataverseTableMetadata(entityXml) {
       continue;
     }
     attributes.push({
+      choiceOptionsByLabel: parseDataverseChoiceOptions(attributeMatch[3], type),
       logicalName,
       physicalName: decodeXmlEntities(attributeMatch[2].trim()),
       type: type.toLowerCase()
@@ -635,6 +638,26 @@ function parseDataverseTableMetadata(entityXml) {
     primaryKey: primaryKeyAttribute.logicalName,
     schemaName
   };
+}
+
+function parseDataverseChoiceOptions(attributeXml, type) {
+  if (!["bit", "picklist"].includes(type.toLowerCase())) {
+    return null;
+  }
+
+  const options = new Map();
+  const optionPattern = /<option\b[^>]*\bvalue=(["'])(-?\d+)\1[^>]*>([\s\S]*?)<\/option>/gi;
+  let optionMatch;
+  while ((optionMatch = optionPattern.exec(attributeXml)) !== null) {
+    const englishLabelMatch =
+      /<label\b[^>]*\bdescription=(["'])(.*?)\1[^>]*\blanguagecode=(["'])1033\3/i.exec(optionMatch[3]);
+    const anyLabelMatch = /<label\b[^>]*\bdescription=(["'])(.*?)\1/i.exec(optionMatch[3]);
+    const label = englishLabelMatch?.[2] ?? anyLabelMatch?.[2];
+    if (label !== undefined) {
+      options.set(decodeXmlEntities(label.trim()), Number(optionMatch[2]));
+    }
+  }
+  return options;
 }
 
 function matchXmlText(xml, pattern) {
@@ -820,7 +843,7 @@ function findFilesByExtension(currentDirectory, extension) {
   return matches;
 }
 
-function validateWebsiteCodePath(kind, label, root, expectedDirectory, result) {
+function validateWebsiteCodePath(kind, label, root, expectedDirectory, solutionMetadata, result) {
   const websiteCodePath = path.resolve(root, expectedDirectory);
   if (!directoryExists(websiteCodePath)) {
     result.errors.push(`Template "${label}" website-code directory does not exist: ${expectedDirectory}`);
@@ -849,6 +872,119 @@ function validateWebsiteCodePath(kind, label, root, expectedDirectory, result) {
 
   validateWebsiteCodeContents(websiteCodePath, websiteCodePath, label, result);
   validateWebsiteCodeSourceMetadata(websiteCodePath, label, result);
+  validateWebsiteChoiceValues(websiteCodePath, solutionMetadata, label, result);
+}
+
+function validateWebsiteChoiceValues(websiteCodePath, solutionMetadata, label, result) {
+  const contractPath = path.join(websiteCodePath, DATAVERSE_CHOICE_VALUES_FILE);
+  if (!fileExists(contractPath)) {
+    return;
+  }
+
+  const contract = readJsonFile(contractPath, `Dataverse choice values for template "${label}"`, result);
+  if (!contract) {
+    return;
+  }
+  if (!contract.tables || typeof contract.tables !== "object" || Array.isArray(contract.tables)) {
+    result.errors.push(
+      `Template "${label}" ${DATAVERSE_CHOICE_VALUES_FILE} must contain a tables object.`
+    );
+    return;
+  }
+
+  for (const [tableName, attributes] of Object.entries(contract.tables)) {
+    const table = solutionMetadata.tablesByLogicalName.get(tableName.toLowerCase());
+    const tableLocation = `${DATAVERSE_CHOICE_VALUES_FILE} table "${tableName}"`;
+    if (!table) {
+      result.errors.push(
+        `Template "${label}" ${tableLocation} was not found in solution metadata.`
+      );
+      continue;
+    }
+    if (tableName !== table.logicalName) {
+      result.errors.push(
+        `Template "${label}" ${tableLocation} must exactly match "${table.logicalName}".`
+      );
+    }
+    if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {
+      result.errors.push(`Template "${label}" ${tableLocation} must be an object.`);
+      continue;
+    }
+
+    for (const [attributeName, contractOptions] of Object.entries(attributes)) {
+      validateWebsiteChoiceAttribute(
+        table,
+        attributeName,
+        contractOptions,
+        tableLocation,
+        label,
+        result
+      );
+    }
+  }
+}
+
+function validateWebsiteChoiceAttribute(
+  table,
+  attributeName,
+  contractOptions,
+  tableLocation,
+  label,
+  result
+) {
+  const attribute = table.attributesByLogicalName.get(attributeName.toLowerCase());
+  const attributeLocation = `${tableLocation} attribute "${attributeName}"`;
+  if (!attribute) {
+    result.errors.push(
+      `Template "${label}" ${attributeLocation} was not found in solution metadata.`
+    );
+    return;
+  }
+  if (attributeName !== attribute.logicalName) {
+    result.errors.push(
+      `Template "${label}" ${attributeLocation} must exactly match "${attribute.logicalName}".`
+    );
+  }
+  if (!attribute.choiceOptionsByLabel) {
+    result.errors.push(
+      `Template "${label}" ${attributeLocation} does not reference a local choice column.`
+    );
+    return;
+  }
+  if (!contractOptions || typeof contractOptions !== "object" || Array.isArray(contractOptions)) {
+    result.errors.push(`Template "${label}" ${attributeLocation} must be an object.`);
+    return;
+  }
+
+  const contractLabels = new Set(Object.keys(contractOptions));
+  for (const [optionLabel, optionValue] of Object.entries(contractOptions)) {
+    if (!Number.isInteger(optionValue)) {
+      result.errors.push(
+        `Template "${label}" ${attributeLocation} option "${optionLabel}" must be an integer.`
+      );
+      continue;
+    }
+
+    const solutionValue = attribute.choiceOptionsByLabel.get(optionLabel);
+    if (solutionValue === undefined) {
+      result.errors.push(
+        `Template "${label}" ${attributeLocation} option "${optionLabel}" was not found in solution metadata.`
+      );
+    } else if (optionValue !== solutionValue) {
+      result.errors.push(
+        `Template "${label}" ${attributeLocation} option "${optionLabel}" value ${optionValue} ` +
+        `must exactly match solution value ${solutionValue}.`
+      );
+    }
+  }
+
+  for (const optionLabel of attribute.choiceOptionsByLabel.keys()) {
+    if (!contractLabels.has(optionLabel)) {
+      result.errors.push(
+        `Template "${label}" ${attributeLocation} is missing solution option "${optionLabel}".`
+      );
+    }
+  }
 }
 
 function validateWebsiteCodeContents(websiteCodeRoot, currentDirectory, label, result) {
@@ -1242,7 +1378,31 @@ function validateDataverseSeedRecordFields(record, solutionTable, location, scop
       result.errors.push(
         `Template "${label}" Dataverse seed data ${location} property must exactly match "${attribute.logicalName}".`
       );
+    } else {
+      validateDataverseSeedChoiceValue(
+        record[propertyName],
+        attribute,
+        location,
+        scope,
+        label,
+        result
+      );
     }
+  }
+}
+
+function validateDataverseSeedChoiceValue(value, attribute, location, scope, label, result) {
+  if (value === null || !attribute.choiceOptionsByLabel) {
+    return;
+  }
+
+  const validValues = new Set(attribute.choiceOptionsByLabel.values());
+  if (!Number.isInteger(value) || !validValues.has(value)) {
+    const expectedValues = [...validValues].sort((left, right) => left - right).join(", ");
+    result.errors.push(
+      `Template "${label}" Dataverse seed data ${location} property "${attribute.logicalName}" ` +
+      `value ${JSON.stringify(value)} must match a solution choice value in ${scope}: ${expectedValues}.`
+    );
   }
 }
 

--- a/templates/scripts/validate-templates.test.js
+++ b/templates/scripts/validate-templates.test.js
@@ -346,6 +346,91 @@ test("accepts Dataverse export seed data with fileExports", () => {
   assert.deepEqual(result.errors, []);
 });
 
+test("validates website and seed choice values against solution metadata", () => {
+  const root = createTemplateRoot({
+    solutionTables: [
+      {
+        schemaName: "sample_Request",
+        entitySetName: "sample_requests",
+        primaryKey: "sample_requestid",
+        attributes: [
+          { physicalName: "sample_RequestId", logicalName: "sample_requestid", type: "primarykey" },
+          {
+            physicalName: "sample_Status",
+            logicalName: "sample_status",
+            type: "picklist",
+            choiceOptions: [
+              { label: "Open", value: 100000000 },
+              { label: "Closed", value: 100000001 }
+            ]
+          }
+        ]
+      }
+    ],
+    seedDataPath: "spa/test-template/seed-data/data.json",
+    seedData: {
+      schemaVersion: 1,
+      tables: {
+        requests: {
+          logicalName: "sample_request",
+          entitySet: "sample_requests",
+          idColumn: "sample_requestid",
+          records: [
+            {
+              sample_requestid: "10000000-0000-4000-8000-000000000001",
+              sample_status: 100000000
+            }
+          ]
+        }
+      }
+    }
+  });
+  const websiteCodePath = path.join(root, "spa/test-template/variants/react/website-code");
+  const contractPath = path.join(websiteCodePath, "dataverse-choice-values.json");
+  fs.writeFileSync(contractPath, JSON.stringify({
+    tables: {
+      sample_request: {
+        sample_status: {
+          Open: 100000000,
+          Closed: 100000001
+        }
+      }
+    }
+  }, null, 2));
+
+  assert.deepEqual(validateTemplates({ root }).errors, []);
+
+  const seedPath = path.join(root, "spa/test-template/seed-data/data.json");
+  const seedData = JSON.parse(fs.readFileSync(seedPath, "utf8"));
+  seedData.tables.requests.records[0].sample_status = 42;
+  fs.writeFileSync(seedPath, JSON.stringify(seedData, null, 2));
+
+  const invalidSeedResult = validateTemplates({ root });
+  assert(invalidSeedResult.errors.some((error) =>
+    error.includes('property "sample_status" value 42 must match a solution choice value')
+  ));
+
+  seedData.tables.requests.records[0].sample_status = 100000000;
+  fs.writeFileSync(seedPath, JSON.stringify(seedData, null, 2));
+  fs.writeFileSync(contractPath, JSON.stringify({
+    tables: {
+      sample_request: {
+        sample_status: {
+          Open: 100000001
+        }
+      }
+    }
+  }, null, 2));
+
+  const invalidContractResult = validateTemplates({ root });
+  assert(invalidContractResult.errors.some((error) =>
+    error.includes('option "Open" value 100000001 must exactly match solution value 100000000')
+  ));
+  assert(invalidContractResult.errors.some((error) =>
+    error.includes('is missing solution option "Closed"')
+  ));
+});
+
 test("validates Dataverse seed targets, lookups, records, and dependency order against solution metadata", () => {
   const solutionTables = [
     {
@@ -868,12 +953,27 @@ function writeDataverseMetadata(solutionPath, tables, relationships) {
 }
 
 function dataverseEntityXml(table) {
-  const attributes = table.attributes.map((attribute) => `
+  const attributes = table.attributes.map((attribute) => {
+    const options = (attribute.choiceOptions ?? []).map((option) => `
+              <option value="${option.value}">
+                <labels>
+                  <label description="${option.label}" languagecode="1033" />
+                </labels>
+              </option>`).join("");
+    const optionSet = options ? `
+          <optionset Name="${table.schemaName}_${attribute.logicalName}">
+            <OptionSetType>${attribute.type}</OptionSetType>
+            <options>${options}
+            </options>
+          </optionset>` : "";
+    return `
         <attribute PhysicalName="${attribute.physicalName}">
           <Type>${attribute.type}</Type>
           <Name>${attribute.logicalName}</Name>
           <LogicalName>${attribute.logicalName}</LogicalName>
-        </attribute>`).join("");
+          ${optionSet}
+        </attribute>`;
+  }).join("");
   return `<Entity>
   <Name>${table.schemaName}</Name>
   <EntityInfo>

--- a/templates/spa/311-portal/seed-data/data.json
+++ b/templates/spa/311-portal/seed-data/data.json
@@ -189,8 +189,8 @@
           "spa311_address": "125 King Street East",
           "spa311_latitude": 43.6512,
           "spa311_longitude": -79.3726,
-          "spa311_status": 490890003,
-          "spa311_urgency": 490890002,
+          "spa311_status": 100000003,
+          "spa311_urgency": 100000002,
           "spa311_department": "Transportation",
           "spa311_dateobserved": "2026-07-14T08:30:00Z"
         },
@@ -203,8 +203,8 @@
           "spa311_address": "88 Queen Street West",
           "spa311_latitude": 43.6505,
           "spa311_longitude": -79.3833,
-          "spa311_status": 490890002,
-          "spa311_urgency": 490890001,
+          "spa311_status": 100000002,
+          "spa311_urgency": 100000001,
           "spa311_department": "Transportation",
           "spa311_dateobserved": "2026-07-15T21:10:00Z"
         },
@@ -217,8 +217,8 @@
           "spa311_address": "42 Willow Avenue",
           "spa311_latitude": 43.6647,
           "spa311_longitude": -79.3495,
-          "spa311_status": 490890004,
-          "spa311_urgency": 490890000,
+          "spa311_status": 100000004,
+          "spa311_urgency": 100000000,
           "spa311_department": "Solid Waste",
           "spa311_dateobserved": "2026-07-16T18:00:00Z"
         },
@@ -231,8 +231,8 @@
           "spa311_address": "17 Market Lane",
           "spa311_latitude": 43.6499,
           "spa311_longitude": -79.3708,
-          "spa311_status": 490890001,
-          "spa311_urgency": 490890001,
+          "spa311_status": 100000001,
+          "spa311_urgency": 100000001,
           "spa311_department": "Municipal Licensing",
           "spa311_dateobserved": "2026-07-17T11:45:00Z"
         },
@@ -245,8 +245,8 @@
           "spa311_address": "205 Maple Road",
           "spa311_latitude": 43.6764,
           "spa311_longitude": -79.3901,
-          "spa311_status": 490890002,
-          "spa311_urgency": 490890002,
+          "spa311_status": 100000002,
+          "spa311_urgency": 100000002,
           "spa311_department": "Parks and Forestry",
           "spa311_dateobserved": "2026-07-18T07:20:00Z"
         },
@@ -259,8 +259,8 @@
           "spa311_address": "9 Riverside Park",
           "spa311_latitude": 43.6731,
           "spa311_longitude": -79.4012,
-          "spa311_status": 490890005,
-          "spa311_urgency": 490890000,
+          "spa311_status": 100000005,
+          "spa311_urgency": 100000000,
           "spa311_department": "Parks and Forestry",
           "spa311_dateobserved": "2026-07-18T16:15:00Z"
         },
@@ -273,8 +273,8 @@
           "spa311_address": "310 Harbour Street",
           "spa311_latitude": 43.6426,
           "spa311_longitude": -79.3785,
-          "spa311_status": 490890003,
-          "spa311_urgency": 490890002,
+          "spa311_status": 100000003,
+          "spa311_urgency": 100000002,
           "spa311_department": "Water Services",
           "spa311_dateobserved": "2026-07-19T06:40:00Z"
         },
@@ -287,8 +287,8 @@
           "spa311_address": "71 Cedar Street",
           "spa311_latitude": 43.6598,
           "spa311_longitude": -79.3616,
-          "spa311_status": 490890000,
-          "spa311_urgency": 490890001,
+          "spa311_status": 100000000,
+          "spa311_urgency": 100000001,
           "spa311_department": "Water Services",
           "spa311_dateobserved": "2026-07-20T09:05:00Z"
         },
@@ -301,8 +301,8 @@
           "spa311_address": "156 College Street",
           "spa311_latitude": 43.6583,
           "spa311_longitude": -79.3986,
-          "spa311_status": 490890001,
-          "spa311_urgency": 490890000,
+          "spa311_status": 100000001,
+          "spa311_urgency": 100000000,
           "spa311_department": "Municipal Licensing",
           "spa311_dateobserved": "2026-07-21T22:30:00Z"
         },
@@ -315,8 +315,8 @@
           "spa311_address": "460 Dundas Street West",
           "spa311_latitude": 43.6537,
           "spa311_longitude": -79.4039,
-          "spa311_status": 490890000,
-          "spa311_urgency": 490890000,
+          "spa311_status": 100000000,
+          "spa311_urgency": 100000000,
           "spa311_department": "Transportation",
           "spa311_dateobserved": "2026-07-22T12:10:00Z"
         }
@@ -331,7 +331,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000001",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000001)",
           "spa311_name": "Request received",
-          "spa311_status": 490890000,
+          "spa311_status": 100000000,
           "spa311_updatedate": "2026-07-14T08:35:00Z",
           "spa311_note": "The request was submitted and assigned a tracking number."
         },
@@ -339,7 +339,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000002",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000001)",
           "spa311_name": "Crew assigned",
-          "spa311_status": 490890003,
+          "spa311_status": 100000003,
           "spa311_updatedate": "2026-07-16T09:00:00Z",
           "spa311_note": "A road-maintenance crew has been assigned."
         },
@@ -347,7 +347,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000003",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000002)",
           "spa311_name": "Inspection scheduled",
-          "spa311_status": 490890002,
+          "spa311_status": 100000002,
           "spa311_updatedate": "2026-07-16T10:15:00Z",
           "spa311_note": "A lighting technician will inspect the crossing."
         },
@@ -355,7 +355,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000004",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000003)",
           "spa311_name": "Collection completed",
-          "spa311_status": 490890004,
+          "spa311_status": 100000004,
           "spa311_updatedate": "2026-07-17T14:25:00Z",
           "spa311_note": "The missed recycling collection was completed."
         },
@@ -363,7 +363,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000005",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000004)",
           "spa311_name": "Request reviewed",
-          "spa311_status": 490890001,
+          "spa311_status": 100000001,
           "spa311_updatedate": "2026-07-18T08:50:00Z",
           "spa311_note": "The report was sent to the field-inspection queue."
         },
@@ -371,7 +371,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000006",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000005)",
           "spa311_name": "Forestry review",
-          "spa311_status": 490890002,
+          "spa311_status": 100000002,
           "spa311_updatedate": "2026-07-19T11:00:00Z",
           "spa311_note": "Forestry staff are reviewing the reported clearance issue."
         },
@@ -379,7 +379,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000007",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000006)",
           "spa311_name": "Removal completed",
-          "spa311_status": 490890005,
+          "spa311_status": 100000005,
           "spa311_updatedate": "2026-07-20T13:35:00Z",
           "spa311_note": "The graffiti was removed from the retaining wall."
         },
@@ -387,7 +387,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000008",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000007)",
           "spa311_name": "Emergency repair dispatched",
-          "spa311_status": 490890003,
+          "spa311_status": 100000003,
           "spa311_updatedate": "2026-07-19T07:10:00Z",
           "spa311_note": "Water Services dispatched a repair crew."
         },
@@ -395,7 +395,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000009",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000008)",
           "spa311_name": "Request received",
-          "spa311_status": 490890000,
+          "spa311_status": 100000000,
           "spa311_updatedate": "2026-07-20T09:12:00Z",
           "spa311_note": "The storm-drain request is awaiting review."
         },
@@ -403,7 +403,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000010",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000009)",
           "spa311_name": "Bylaw review",
-          "spa311_status": 490890001,
+          "spa311_status": 100000001,
           "spa311_updatedate": "2026-07-22T09:30:00Z",
           "spa311_note": "The concern was routed to municipal licensing."
         },
@@ -411,7 +411,7 @@
           "spa311_statusupdateid": "40000000-0000-4000-8000-000000000011",
           "spa311_ServiceRequestId@odata.bind": "/spa311_servicerequests(30000000-0000-4000-8000-000000000010)",
           "spa311_name": "Request received",
-          "spa311_status": 490890000,
+          "spa311_status": 100000000,
           "spa311_updatedate": "2026-07-22T12:20:00Z",
           "spa311_note": "The pothole report was submitted for transportation review."
         }

--- a/templates/spa/311-portal/solutions/311Portal/Entities/spa311_ServiceRequest/Entity.xml
+++ b/templates/spa/311-portal/solutions/311Portal/Entities/spa311_ServiceRequest/Entity.xml
@@ -923,32 +923,32 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="490890000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Submitted" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Reviewed" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Assigned" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="In Progress" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890004" ExternalValue="" IsHidden="0">
+              <option value="100000004" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Resolved" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890005" ExternalValue="" IsHidden="0">
+              <option value="100000005" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Closed" languagecode="1033" />
                 </labels>
@@ -997,17 +997,17 @@
               <displayname description="Urgency" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="490890000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Low" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Medium" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="High" languagecode="1033" />
                 </labels>

--- a/templates/spa/311-portal/solutions/311Portal/Entities/spa311_StatusUpdate/Entity.xml
+++ b/templates/spa/311-portal/solutions/311Portal/Entities/spa311_StatusUpdate/Entity.xml
@@ -631,32 +631,32 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="490890000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Submitted" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Reviewed" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Assigned" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="In Progress" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890004" ExternalValue="" IsHidden="0">
+              <option value="100000004" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Resolved" languagecode="1033" />
                 </labels>
               </option>
-              <option value="490890005" ExternalValue="" IsHidden="0">
+              <option value="100000005" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Closed" languagecode="1033" />
                 </labels>

--- a/templates/spa/311-portal/variants/react/website-code/dataverse-choice-values.json
+++ b/templates/spa/311-portal/variants/react/website-code/dataverse-choice-values.json
@@ -1,0 +1,29 @@
+{
+  "tables": {
+    "spa311_servicerequest": {
+      "spa311_status": {
+        "Submitted": 100000000,
+        "Reviewed": 100000001,
+        "Assigned": 100000002,
+        "In Progress": 100000003,
+        "Resolved": 100000004,
+        "Closed": 100000005
+      },
+      "spa311_urgency": {
+        "Low": 100000000,
+        "Medium": 100000001,
+        "High": 100000002
+      }
+    },
+    "spa311_statusupdate": {
+      "spa311_status": {
+        "Submitted": 100000000,
+        "Reviewed": 100000001,
+        "Assigned": 100000002,
+        "In Progress": 100000003,
+        "Resolved": 100000004,
+        "Closed": 100000005
+      }
+    }
+  }
+}

--- a/templates/spa/311-portal/variants/react/website-code/src/types/serviceRequest.ts
+++ b/templates/spa/311-portal/variants/react/website-code/src/types/serviceRequest.ts
@@ -11,25 +11,28 @@ import { getFormattedValue } from '../shared/powerPagesApi'
 import type { ServiceTypeEntity } from './serviceType'
 import type { CategoryEntity } from './category'
 import type { ContactEntity } from './contact'
+import choiceValues from '../../dataverse-choice-values.json'
 
 // -- Status Picklist ----------------------------------------------------------
 
+const statusValues = choiceValues.tables.spa311_servicerequest.spa311_status
+
 export const ServiceRequestStatusMap = {
-  490890000: 'submitted',
-  490890001: 'reviewed',
-  490890002: 'assigned',
-  490890003: 'in-progress',
-  490890004: 'resolved',
-  490890005: 'closed',
+  [statusValues.Submitted]: 'submitted',
+  [statusValues.Reviewed]: 'reviewed',
+  [statusValues.Assigned]: 'assigned',
+  [statusValues['In Progress']]: 'in-progress',
+  [statusValues.Resolved]: 'resolved',
+  [statusValues.Closed]: 'closed',
 } as const
 
 export const ServiceRequestStatusReverse: Record<string, number> = {
-  submitted: 490890000,
-  reviewed: 490890001,
-  assigned: 490890002,
-  'in-progress': 490890003,
-  resolved: 490890004,
-  closed: 490890005,
+  submitted: statusValues.Submitted,
+  reviewed: statusValues.Reviewed,
+  assigned: statusValues.Assigned,
+  'in-progress': statusValues['In Progress'],
+  resolved: statusValues.Resolved,
+  closed: statusValues.Closed,
 }
 
 export type RequestStatus = 'submitted' | 'reviewed' | 'assigned' | 'in-progress' | 'resolved' | 'closed'
@@ -44,16 +47,18 @@ export const mapStatusToPicklist = (status: RequestStatus): number =>
 
 // -- Urgency Picklist ---------------------------------------------------------
 
+const urgencyValues = choiceValues.tables.spa311_servicerequest.spa311_urgency
+
 export const UrgencyMap = {
-  490890000: 'low',
-  490890001: 'medium',
-  490890002: 'high',
+  [urgencyValues.Low]: 'low',
+  [urgencyValues.Medium]: 'medium',
+  [urgencyValues.High]: 'high',
 } as const
 
 export const UrgencyReverse: Record<string, number> = {
-  low: 490890000,
-  medium: 490890001,
-  high: 490890002,
+  low: urgencyValues.Low,
+  medium: urgencyValues.Medium,
+  high: urgencyValues.High,
 }
 
 export type Urgency = 'low' | 'medium' | 'high'

--- a/templates/spa/311-portal/variants/react/website-code/tests/serviceRequests.test.mjs
+++ b/templates/spa/311-portal/variants/react/website-code/tests/serviceRequests.test.mjs
@@ -46,7 +46,7 @@ function mockApi(handler) {
 test('status values match the packaged Dataverse solution in both directions', () => {
     const statuses = ['submitted', 'reviewed', 'assigned', 'in-progress', 'resolved', 'closed']
     for (const [index, status] of statuses.entries()) {
-        const value = 490890000 + index
+        const value = 100000000 + index
         assert.equal(mappings.mapStatusToPicklist(status), value)
         assert.equal(mappings.mapStatusFromPicklist(value), status)
     }
@@ -54,7 +54,7 @@ test('status values match the packaged Dataverse solution in both directions', (
 
 test('urgency values match the packaged Dataverse solution in both directions', () => {
     for (const [index, urgency] of ['low', 'medium', 'high'].entries()) {
-        const value = 490890000 + index
+        const value = 100000000 + index
         assert.equal(mappings.mapUrgencyToPicklist(urgency), value)
         assert.equal(mappings.mapUrgencyFromPicklist(value), urgency)
     }
@@ -67,8 +67,8 @@ for (const [index, urgency] of ['low', 'medium', 'high'].entries()) {
             if (options.method === 'POST') {
                 assert.equal(url, '/_api/spa311_servicerequests')
                 posted = JSON.parse(options.body)
-                assert.equal(posted.spa311_status, 490890000)
-                assert.equal(posted.spa311_urgency, 490890000 + index)
+                assert.equal(posted.spa311_status, 100000000)
+                assert.equal(posted.spa311_urgency, 100000000 + index)
                 assert.equal(posted['spa311_CategoryId@odata.bind'], `/spa311_categories(${input.categoryId})`)
                 assert.equal(posted['spa311_ServiceTypeId@odata.bind'], `/spa311_servicetypes(${input.serviceTypeId})`)
                 assert.match(posted.spa311_requestnumber, /^SR-\d{8}-\d{5}$/)
@@ -140,7 +140,7 @@ test('updates use the corrected choice values and decode the returned status', a
     mockApi((_url, options) => {
         if (options.method === 'PATCH') {
             patched = JSON.parse(options.body)
-            assert.deepEqual(patched, { spa311_status: 490890004, spa311_urgency: 490890002 })
+            assert.deepEqual(patched, { spa311_status: 100000004, spa311_urgency: 100000002 })
             return new Response(null, { status: 204 })
         }
         return Response.json({ ...patched, spa311_servicerequestid: recordId })

--- a/templates/spa/311-portal/variants/react/website-code/tsconfig.json
+++ b/templates/spa/311-portal/variants/react/website-code/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/templates/spa/supplier-invoice-portal/seed-data/data.json
+++ b/templates/spa/supplier-invoice-portal/seed-data/data.json
@@ -98,7 +98,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-001",
-          "spnvc_postatus": 132140001,
+          "spnvc_postatus": 2,
           "spnvc_totalamount": 15000
         },
         {
@@ -111,7 +111,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-002",
-          "spnvc_postatus": 132140001,
+          "spnvc_postatus": 2,
           "spnvc_totalamount": 32500
         },
         {
@@ -124,7 +124,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-003",
-          "spnvc_postatus": 132140002,
+          "spnvc_postatus": 3,
           "spnvc_totalamount": 8750
         },
         {
@@ -137,7 +137,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-004",
-          "spnvc_postatus": 132140001,
+          "spnvc_postatus": 2,
           "spnvc_totalamount": 22000
         },
         {
@@ -150,7 +150,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-005",
-          "spnvc_postatus": 132140000,
+          "spnvc_postatus": 1,
           "spnvc_totalamount": 12300
         },
         {
@@ -163,7 +163,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-006",
-          "spnvc_postatus": 132140000,
+          "spnvc_postatus": 1,
           "spnvc_totalamount": 18900
         },
         {
@@ -176,7 +176,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-007",
-          "spnvc_postatus": 132140003,
+          "spnvc_postatus": 4,
           "spnvc_totalamount": 45000
         },
         {
@@ -189,7 +189,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-008",
-          "spnvc_postatus": 132140001,
+          "spnvc_postatus": 2,
           "spnvc_totalamount": 28400
         },
         {
@@ -202,7 +202,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-009",
-          "spnvc_postatus": 132140004,
+          "spnvc_postatus": 5,
           "spnvc_totalamount": 9600
         },
         {
@@ -215,7 +215,7 @@
           "_transactioncurrencyid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "transactioncurrencyid",
           "_transactioncurrencyid_value": "58337f5b-5f62-ef11-bfe2-002248046590",
           "spnvc_name": "PO-2026-010",
-          "spnvc_postatus": 132140001,
+          "spnvc_postatus": 2,
           "spnvc_totalamount": 16750
         }
       ]
@@ -240,7 +240,7 @@
           "_spnvc_purchaseorderid_value": null,
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "60a29644-9d11-f111-8406-000d3a5bf33c",
-          "spnvc_invoicestatus": 132140004
+          "spnvc_invoicestatus": 5
         },
         {
           "@odata.etag": "W/\"38974672\"",
@@ -257,7 +257,7 @@
           "_spnvc_purchaseorderid_value": null,
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "60a29644-9d11-f111-8406-000d3a5bf33c",
-          "spnvc_invoicestatus": 132140004
+          "spnvc_invoicestatus": 5
         },
         {
           "@odata.etag": "W/\"39017467\"",
@@ -274,7 +274,7 @@
           "_spnvc_purchaseorderid_value": null,
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "60a29644-9d11-f111-8406-000d3a5bf33c",
-          "spnvc_invoicestatus": 132140003
+          "spnvc_invoicestatus": 4
         },
         {
           "@odata.etag": "W/\"40766389\"",
@@ -293,7 +293,7 @@
           "_spnvc_purchaseorderid_value": "f52b7e24-da26-f111-8341-000d3a37e531",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140004
+          "spnvc_invoicestatus": 5
         },
         {
           "@odata.etag": "W/\"40769402\"",
@@ -310,7 +310,7 @@
           "_spnvc_purchaseorderid_value": null,
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140001
+          "spnvc_invoicestatus": 2
         },
         {
           "@odata.etag": "W/\"40769405\"",
@@ -327,7 +327,7 @@
           "_spnvc_purchaseorderid_value": null,
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140001
+          "spnvc_invoicestatus": 2
         },
         {
           "@odata.etag": "W/\"40766384\"",
@@ -346,7 +346,7 @@
           "_spnvc_purchaseorderid_value": "f52b7e24-da26-f111-8341-000d3a37e531",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140001
+          "spnvc_invoicestatus": 2
         },
         {
           "@odata.etag": "W/\"40766393\"",
@@ -365,7 +365,7 @@
           "_spnvc_purchaseorderid_value": "c7a71336-da26-f111-8341-000d3a36e41e",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140002
+          "spnvc_invoicestatus": 3
         },
         {
           "@odata.etag": "W/\"40766387\"",
@@ -384,7 +384,7 @@
           "_spnvc_purchaseorderid_value": "8e0f5d38-da26-f111-8341-000d3a37e531",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140006
+          "spnvc_invoicestatus": 7
         },
         {
           "@odata.etag": "W/\"40766391\"",
@@ -403,7 +403,7 @@
           "_spnvc_purchaseorderid_value": "0515b442-da26-f111-8341-000d3a58dd8c",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140000
+          "spnvc_invoicestatus": 1
         },
         {
           "@odata.etag": "W/\"40766395\"",
@@ -422,7 +422,7 @@
           "_spnvc_purchaseorderid_value": "23548357-da26-f111-8341-000d3a36e41e",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140006
+          "spnvc_invoicestatus": 7
         },
         {
           "@odata.etag": "W/\"40766397\"",
@@ -441,7 +441,7 @@
           "_spnvc_purchaseorderid_value": "71ca6963-da26-f111-8341-000d3a37e531",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140001
+          "spnvc_invoicestatus": 2
         },
         {
           "@odata.etag": "W/\"40766399\"",
@@ -460,7 +460,7 @@
           "_spnvc_purchaseorderid_value": "34831367-da26-f111-8341-000d3a5bf33c",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140005
+          "spnvc_invoicestatus": 6
         },
         {
           "@odata.etag": "W/\"40766401\"",
@@ -479,7 +479,7 @@
           "_spnvc_purchaseorderid_value": "d7ee956a-da26-f111-8341-000d3a58dd8c",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140003
+          "spnvc_invoicestatus": 4
         },
         {
           "@odata.etag": "W/\"40766402\"",
@@ -498,7 +498,7 @@
           "_spnvc_purchaseorderid_value": "0515b442-da26-f111-8341-000d3a58dd8c",
           "_spnvc_contactid_value@Microsoft.Dynamics.CRM.associatednavigationproperty": "spnvc_ContactId",
           "_spnvc_contactid_value": "59d2f304-6470-ef11-a671-002248091d8b",
-          "spnvc_invoicestatus": 132140002
+          "spnvc_invoicestatus": 3
         }
       ]
     },

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Dealer/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Dealer/Entity.xml
@@ -890,22 +890,22 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Active" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Onboarding" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Inactive" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Suspended" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Invoice/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Invoice/Entity.xml
@@ -788,37 +788,37 @@
               <displayname description="Invoice Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="1" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Draft" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="2" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Submitted" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="3" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Under Review" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="4" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Needs Revision" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140004" ExternalValue="" IsHidden="0">
+              <option value="5" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Approved" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140005" ExternalValue="" IsHidden="0">
+              <option value="6" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Rejected" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140006" ExternalValue="" IsHidden="0">
+              <option value="7" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Paid" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Order/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Order/Entity.xml
@@ -744,12 +744,12 @@
               <displayname description="Order Type" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Purchase" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Sales" languagecode="1033" />
                 </labels>
@@ -798,27 +798,27 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Pending" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Processing" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Shipped" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Delivered" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140004" ExternalValue="" IsHidden="0">
+              <option value="100000004" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Cancelled" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Product/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Product/Entity.xml
@@ -563,22 +563,22 @@
               <displayname description="Category" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Raw Materials" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Components" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Finished Goods" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Packaging" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_PurchaseOrder/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_PurchaseOrder/Entity.xml
@@ -673,32 +673,32 @@
               <displayname description="PO Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="1" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Draft" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="2" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Issued" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="3" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Partially Invoiced" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="4" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Fully Invoiced" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140004" ExternalValue="" IsHidden="0">
+              <option value="5" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Closed" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140005" ExternalValue="" IsHidden="0">
+              <option value="6" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Cancelled" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Shipment/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Shipment/Entity.xml
@@ -813,22 +813,22 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="In Transit" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Delivered" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Delayed" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Cancelled" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Supplier/Entity.xml
+++ b/templates/spa/supplier-invoice-portal/solutions/SupplierInvoiceSPAPortal/Entities/spnvc_Supplier/Entity.xml
@@ -817,22 +817,22 @@
               <displayname description="Status" languagecode="1033" />
             </displaynames>
             <options>
-              <option value="132140000" ExternalValue="" IsHidden="0">
+              <option value="100000000" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Active" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140001" ExternalValue="" IsHidden="0">
+              <option value="100000001" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Pending" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140002" ExternalValue="" IsHidden="0">
+              <option value="100000002" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Inactive" languagecode="1033" />
                 </labels>
               </option>
-              <option value="132140003" ExternalValue="" IsHidden="0">
+              <option value="100000003" ExternalValue="" IsHidden="0">
                 <labels>
                   <label description="Suspended" languagecode="1033" />
                 </labels>

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/dataverse-choice-values.json
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/dataverse-choice-values.json
@@ -1,0 +1,80 @@
+{
+  "tables": {
+    "spnvc_carrier": {
+      "spnvc_isactive": {
+        "Yes": 1,
+        "No": 0
+      }
+    },
+    "spnvc_dealer": {
+      "spnvc_status": {
+        "Active": 100000000,
+        "Onboarding": 100000001,
+        "Inactive": 100000002,
+        "Suspended": 100000003
+      }
+    },
+    "spnvc_invoice": {
+      "spnvc_invoicestatus": {
+        "Draft": 1,
+        "Submitted": 2,
+        "Under Review": 3,
+        "Needs Revision": 4,
+        "Approved": 5,
+        "Rejected": 6,
+        "Paid": 7
+      }
+    },
+    "spnvc_order": {
+      "spnvc_ordertype": {
+        "Purchase": 100000000,
+        "Sales": 100000001
+      },
+      "spnvc_status": {
+        "Pending": 100000000,
+        "Processing": 100000001,
+        "Shipped": 100000002,
+        "Delivered": 100000003,
+        "Cancelled": 100000004
+      }
+    },
+    "spnvc_product": {
+      "spnvc_category": {
+        "Raw Materials": 100000000,
+        "Components": 100000001,
+        "Finished Goods": 100000002,
+        "Packaging": 100000003
+      },
+      "spnvc_isactive": {
+        "Yes": 1,
+        "No": 0
+      }
+    },
+    "spnvc_purchaseorder": {
+      "spnvc_postatus": {
+        "Draft": 1,
+        "Issued": 2,
+        "Partially Invoiced": 3,
+        "Fully Invoiced": 4,
+        "Closed": 5,
+        "Cancelled": 6
+      }
+    },
+    "spnvc_shipment": {
+      "spnvc_status": {
+        "In Transit": 100000000,
+        "Delivered": 100000001,
+        "Delayed": 100000002,
+        "Cancelled": 100000003
+      }
+    },
+    "spnvc_supplier": {
+      "spnvc_status": {
+        "Active": 100000000,
+        "Pending": 100000001,
+        "Inactive": 100000002,
+        "Suspended": 100000003
+      }
+    }
+  }
+}

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/src/hooks/useReviewQueueSummary.ts
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/src/hooks/useReviewQueueSummary.ts
@@ -11,6 +11,7 @@ import {
   DataSummaryApiError,
   type DataSummaryRecommendation,
 } from '../services/aiSummaryService'
+import { INVOICE_STATUS } from '../types/invoice'
 
 const ENTITY_SET = 'spnvc_invoices'
 const REVIEW_QUEUE_SELECT = [
@@ -24,10 +25,11 @@ const REVIEW_QUEUE_SELECT = [
 const REVIEW_QUEUE_EXPAND = [
   'spnvc_SupplierId($select=spnvc_name)',
 ].join(',')
-// Submitted = 2, Under Review = 3 — mirrors the page's existing filter scope.
-// No $top / Prefer: odata.maxpagesize — those are pagination concerns for the UI
+// No $top / Prefer: odata.maxpagesize - those are pagination concerns for the UI
 // table; the summary is bounded by Summarization/Data/ContentSizeLimit.
-const REVIEW_QUEUE_FILTER = 'spnvc_invoicestatus eq 2 or spnvc_invoicestatus eq 3'
+const REVIEW_QUEUE_FILTER =
+  `spnvc_invoicestatus eq ${INVOICE_STATUS.Submitted} ` +
+  `or spnvc_invoicestatus eq ${INVOICE_STATUS['Under Review']}`
 const REVIEW_QUEUE_ORDERBY = 'spnvc_submissiondate asc'
 const REVIEW_QUEUE_INSTRUCTION = 'Summarization/prompt/reviewqueue_summary'
 

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/src/services/invoiceService.ts
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/src/services/invoiceService.ts
@@ -18,6 +18,7 @@ import {
   type UpdateInvoiceInput,
   type InvoiceStatusLabel,
   INVOICE_STATUS,
+  INVOICE_STATUS_VALUE_TO_LABEL,
   mapInvoiceEntity,
 } from '../types/invoice'
 
@@ -246,20 +247,10 @@ export const getInvoiceCountByStatus = async (): Promise<
 
   const response = await powerPagesFetch<ODataCollectionResponse<Record<string, unknown>>>(url)
 
-  const STATUS_VALUE_TO_LABEL: Record<number, InvoiceStatusLabel> = {
-    1: 'Draft',
-    2: 'Submitted',
-    3: 'Under Review',
-    4: 'Needs Revision',
-    5: 'Approved',
-    6: 'Rejected',
-    7: 'Paid',
-  }
-
   return (response?.value ?? []).map((row) => {
     const statusValue = row['spnvc_invoicestatus'] as number
     return {
-      status: STATUS_VALUE_TO_LABEL[statusValue] ?? 'Draft',
+      status: INVOICE_STATUS_VALUE_TO_LABEL[statusValue] ?? 'Draft',
       statusValue,
       count: row['count'] as number,
     }

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/src/services/purchaseOrderService.ts
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/src/services/purchaseOrderService.ts
@@ -18,6 +18,7 @@ import {
   type UpdatePurchaseOrderInput,
   type POStatusLabel,
   PO_STATUS,
+  PO_STATUS_VALUE_TO_LABEL,
   mapPurchaseOrderEntity,
 } from '../types/purchaseOrder'
 
@@ -201,19 +202,10 @@ export const getPOCountByStatus = async (): Promise<
 
   const response = await powerPagesFetch<ODataCollectionResponse<Record<string, unknown>>>(url)
 
-  const STATUS_VALUE_TO_LABEL: Record<number, POStatusLabel> = {
-    1: 'Draft',
-    2: 'Issued',
-    3: 'Partially Invoiced',
-    4: 'Fully Invoiced',
-    5: 'Closed',
-    6: 'Cancelled',
-  }
-
   return (response?.value ?? []).map((row) => {
     const statusValue = row['spnvc_postatus'] as number
     return {
-      status: STATUS_VALUE_TO_LABEL[statusValue] ?? 'Draft',
+      status: PO_STATUS_VALUE_TO_LABEL[statusValue] ?? 'Draft',
       statusValue,
       count: row['count'] as number,
     }

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/src/types/invoice.ts
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/src/types/invoice.ts
@@ -3,6 +3,7 @@
 // Column names verified against actual Dataverse metadata on 2026-03-19.
 
 import { getFormattedValue } from '../services/powerPagesApi'
+import choiceValues from '../../dataverse-choice-values.json'
 
 // -- Raw OData Entity ---------------------------------------------------------
 // Matches Dataverse column logical names exactly.
@@ -33,15 +34,9 @@ export interface InvoiceEntity {
 // -- Invoice Status Option Set ------------------------------------------------
 // Values verified from Dataverse PicklistAttributeMetadata.
 
-export const INVOICE_STATUS = {
-  Draft: 1,
-  Submitted: 2,
-  'Under Review': 3,
-  'Needs Revision': 4,
-  Approved: 5,
-  Rejected: 6,
-  Paid: 7,
-} as const
+export const INVOICE_STATUS = Object.freeze(
+  choiceValues.tables.spnvc_invoice.spnvc_invoicestatus,
+)
 
 export type InvoiceStatusLabel = keyof typeof INVOICE_STATUS
 export type InvoiceStatusValue = typeof INVOICE_STATUS[InvoiceStatusLabel]
@@ -53,7 +48,7 @@ export function isInvoiceLocked(status: string | undefined): boolean {
   return LOCKED_INVOICE_STATUSES.includes(status as InvoiceStatusLabel)
 }
 
-const STATUS_VALUE_TO_LABEL = Object.fromEntries(
+export const INVOICE_STATUS_VALUE_TO_LABEL = Object.fromEntries(
   Object.entries(INVOICE_STATUS).map(([label, value]) => [value, label]),
 ) as Record<number, InvoiceStatusLabel>
 
@@ -115,8 +110,8 @@ export const mapInvoiceEntity = (entity: InvoiceEntity): Invoice => ({
   submissionDate: entity.spnvc_submissiondate ?? '',
   dueDate: entity.spnvc_duedate ?? '',
   amount: entity.spnvc_amount ?? 0,
-  status: STATUS_VALUE_TO_LABEL[entity.spnvc_invoicestatus ?? 0] ?? 'Draft',
-  statusValue: entity.spnvc_invoicestatus ?? 1,
+  status: INVOICE_STATUS_VALUE_TO_LABEL[entity.spnvc_invoicestatus ?? 0] ?? 'Draft',
+  statusValue: entity.spnvc_invoicestatus ?? INVOICE_STATUS.Draft,
   contactId: entity._spnvc_contactid_value,
   contactName:
     getFormattedValue(entity, '_spnvc_contactid_value')

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/src/types/purchaseOrder.ts
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/src/types/purchaseOrder.ts
@@ -2,6 +2,7 @@
 // TypeScript types for the spnvc_purchaseorder Dataverse table.
 
 import { getFormattedValue } from '../services/powerPagesApi'
+import choiceValues from '../../dataverse-choice-values.json'
 
 // -- Raw OData Entity ---------------------------------------------------------
 
@@ -25,14 +26,9 @@ export interface PurchaseOrderEntity {
 
 // -- PO Status Option Set -----------------------------------------------------
 
-export const PO_STATUS = {
-  Draft: 1,
-  Issued: 2,
-  'Partially Invoiced': 3,
-  'Fully Invoiced': 4,
-  Closed: 5,
-  Cancelled: 6,
-} as const
+export const PO_STATUS = Object.freeze(
+  choiceValues.tables.spnvc_purchaseorder.spnvc_postatus,
+)
 
 export type POStatusLabel = keyof typeof PO_STATUS
 export type POStatusValue = typeof PO_STATUS[POStatusLabel]
@@ -44,7 +40,7 @@ export function isPOLocked(status: string | undefined): boolean {
   return LOCKED_PO_STATUSES.includes(status as POStatusLabel)
 }
 
-const STATUS_VALUE_TO_LABEL = Object.fromEntries(
+export const PO_STATUS_VALUE_TO_LABEL = Object.fromEntries(
   Object.entries(PO_STATUS).map(([label, value]) => [value, label]),
 ) as Record<number, POStatusLabel>
 
@@ -98,8 +94,8 @@ export const mapPurchaseOrderEntity = (entity: PurchaseOrderEntity): PurchaseOrd
     invoicedAmount: 0, // Will be computed from linked invoices
     remainingAmount: totalAmount,
     deliveryDate: entity.spnvc_deliverydate ?? '',
-    status: STATUS_VALUE_TO_LABEL[entity.spnvc_postatus ?? 0] ?? 'Draft',
-    statusValue: entity.spnvc_postatus ?? 1,
+    status: PO_STATUS_VALUE_TO_LABEL[entity.spnvc_postatus ?? 0] ?? 'Draft',
+    statusValue: entity.spnvc_postatus ?? PO_STATUS.Draft,
     supplierId: entity._spnvc_supplierid_value,
     supplierName:
       getFormattedValue(entity, '_spnvc_supplierid_value')

--- a/templates/spa/supplier-invoice-portal/variants/react/website-code/tsconfig.json
+++ b/templates/spa/supplier-invoice-portal/variants/react/website-code/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary

Restore the choice integers from the authoritative supporting-solution exports and use them consistently in solution metadata, website code, and seed data for both SPA template families.

The mismatch came from re-prefixed unpacked solutions assigning publisher-range values while the original field contracts used either `100000000+` custom values or compact status values. No global option sets are used by these templates.

## Corrected contracts

| Template | Table.attribute | Labels | Before | After |
|---|---|---|---|---|
| 311 Portal | `spa311_servicerequest.spa311_status` | Submitted, Reviewed, Assigned, In Progress, Resolved, Closed | `490890000..490890005` | `100000000..100000005` |
| 311 Portal | `spa311_statusupdate.spa311_status` | Submitted, Reviewed, Assigned, In Progress, Resolved, Closed | `490890000..490890005` | `100000000..100000005` |
| 311 Portal | `spa311_servicerequest.spa311_urgency` | Low, Medium, High | `490890000..490890002` | `100000000..100000002` |
| Supplier Invoice Portal | `spnvc_invoice.spnvc_invoicestatus` | Draft, Submitted, Under Review, Needs Revision, Approved, Rejected, Paid | `132140000..132140006` | `1..7` |
| Supplier Invoice Portal | `spnvc_purchaseorder.spnvc_postatus` | Draft, Issued, Partially Invoiced, Fully Invoiced, Closed, Cancelled | `132140000..132140005` | `1..6` |
| Supplier Invoice Portal | `spnvc_dealer.spnvc_status` | Active, Onboarding, Inactive, Suspended | `132140000..132140003` | `100000000..100000003` |
| Supplier Invoice Portal | `spnvc_order.spnvc_ordertype` | Purchase, Sales | `132140000..132140001` | `100000000..100000001` |
| Supplier Invoice Portal | `spnvc_order.spnvc_status` | Pending, Processing, Shipped, Delivered, Cancelled | `132140000..132140004` | `100000000..100000004` |
| Supplier Invoice Portal | `spnvc_product.spnvc_category` | Raw Materials, Components, Finished Goods, Packaging | `132140000..132140003` | `100000000..100000003` |
| Supplier Invoice Portal | `spnvc_shipment.spnvc_status` | In Transit, Delivered, Delayed, Cancelled | `132140000..132140003` | `100000000..100000003` |
| Supplier Invoice Portal | `spnvc_supplier.spnvc_status` | Active, Pending, Inactive, Suspended | `132140000..132140003` | `100000000..100000003` |
| Supplier Invoice Portal | `spnvc_carrier.spnvc_isactive`, `spnvc_product.spnvc_isactive` | Yes, No | `1, 0` | unchanged |

The website projects now import their choice values from `dataverse-choice-values.json`. The template validator parses local picklist and bit metadata, checks those website contracts label-for-label and value-for-value, and rejects seed records containing values outside the packaged solution metadata.

## Validation

- Focused choice contract validator test
- All 31 template validator and supplier postbuild tests
- Template manifest validator
- 311 Portal website tests and production build
- Supplier Invoice Portal production build
- Unmanaged solution packing for both supporting solutions
- Authoritative/current custom choice metadata comparison
- `git diff --check`