### PR TITLE
Fix Dependabot alerts in js-yaml and hono

### DIFF
--- a/samples/spa/apps/car-sales-website/angular/package-lock.json
+++ b/samples/spa/apps/car-sales-website/angular/package-lock.json
@@ -8275,8 +8275,8 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "integrity": "sha1-nW+0/wHWqPo6ApC04SDaGeoYG5s=",
+      "version": "4.13.5",
+      "integrity": "sha1-PflGPEZooDIcOVFTCfWJHjiOlwk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8987,8 +8987,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/car-sales-website/react/package-lock.json
+++ b/samples/spa/apps/car-sales-website/react/package-lock.json
@@ -3188,8 +3188,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/car-sales-website/react/package.json
+++ b/samples/spa/apps/car-sales-website/react/package.json
@@ -37,7 +37,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "@babel/core": "7.29.6",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "form-data": "4.0.6"
   }
 }

--- a/samples/spa/apps/credit-cards-website/react/package-lock.json
+++ b/samples/spa/apps/credit-cards-website/react/package-lock.json
@@ -4720,8 +4720,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/apps/credit-cards-website/react/package.json
+++ b/samples/spa/apps/credit-cards-website/react/package.json
@@ -84,7 +84,7 @@
     },
     "overrides": {
         "esbuild": "0.28.1",
-        "js-yaml": "4.3.1",
+        "js-yaml": "4.3.2",
         "nanoid": "3.3.18",
         "postcss-selector-parser": "6.1.3"
     }

--- a/samples/spa/snippets/localization/package-lock.json
+++ b/samples/spa/snippets/localization/package-lock.json
@@ -2958,8 +2958,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.3.2",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {

--- a/samples/spa/snippets/localization/package.json
+++ b/samples/spa/snippets/localization/package.json
@@ -36,6 +36,6 @@
   "overrides": {
     "esbuild": "0.28.1",
     "@babel/core": "7.29.6",
-    "js-yaml": "4.3.1"
+    "js-yaml": "4.3.2"
   }
 }


### PR DESCRIPTION
Resolves six Dependabot alerts in sample development dependencies: four high-severity `js-yaml` alerts and two moderate-severity Hono alerts.

Updates `js-yaml` from `4.3.1` to `4.3.2` across the Angular and React car-sales samples, the credit-cards sample, and the localization snippet to address CVE-2026-84375.
Updates Hono from `4.12.34` to `4.13.5` in the Angular sample to address CVE-2026-84363 and CVE-2026-84365.

The change refreshes existing `js-yaml` overrides and regenerates lockfiles with npm.
It adds no new overrides, changes no application code, and preserves existing dependency ranges and unrelated package versions.

## Validation

- All four production builds passed.
- All five Angular tests passed in ChromeHeadless, and installed dependency trees contain the patched versions.
- `npm run lint` still fails in the three React samples, with identical failures reproduced on the original dependencies: missing ESLint configurations in car-sales and localization, and 17 errors plus one warning in credit-cards. These pre-existing issues are outside this dependency-only change.